### PR TITLE
Revert "[build] add out of tree modules (mod_coreclr, mod_janus, and …

### DIFF
--- a/build/modules.conf.in
+++ b/build/modules.conf.in
@@ -170,10 +170,5 @@ xml_int/mod_xml_scgi
 
 #../../libs/freetdm/mod_freetdm
 
-## Out of tree modules - open issues in their respective repositories
-#mod_coreclr|https://github.com/freeswitch/mod_coreclr.git -b master
-#mod_janus|https://github.com/freeswitch/mod_janus.git -b master
-#mod_mosquitto|https://github.com/freeswitch/mod_mosquitto.git -b master
-
 ## Experimental Modules (don't cry if they're broken)
 #../../contrib/mod/xml_int/mod_xml_odbc


### PR DESCRIPTION
…mod_mosquitto) to modules.conf.  Uncomment their line(s) to include them in your build."

This reverts commit 6b39f3a3e2a697c64bb33cba9f95531bcf0d2b96.

Disabling until we can figure out the drone build issue